### PR TITLE
感情入力画面のデザイン改善

### DIFF
--- a/ParentFeel/Localizable.xcstrings
+++ b/ParentFeel/Localizable.xcstrings
@@ -12,6 +12,7 @@
       }
     },
     "OK" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -112,6 +113,7 @@
       }
     },
     "メモ(任意)" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -284,6 +286,9 @@
         }
       }
     },
+    "変更する" : {
+
+    },
     "失望" : {
       "localizations" : {
         "en" : {
@@ -315,6 +320,7 @@
       }
     },
     "子どもの行動(任意)" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -678,6 +684,7 @@
       }
     },
     "自分の行動(任意)" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/ParentFeel/ParentFeel/View/ActionSelectionView/ActionSelectionView.swift
+++ b/ParentFeel/ParentFeel/View/ActionSelectionView/ActionSelectionView.swift
@@ -3,27 +3,49 @@ import SwiftUI
 struct ActionSelectionView<T: ActionType>: View {
     @Binding var selectedActions: Set<T>
     @Environment(\.dismiss) private var dismiss
-
     @StateObject private var viewState = ActionSelectionViewState<T>()
-
+    
     var body: some View {
         NavigationView {
-            List(Array(T.allCases), id: \.self) { action in
-                MultipleSelectionRow(action: action, isSelected: viewState.contains(action)) {
-                    viewState.toggle(action)
+            ZStack {
+                Color.gray.opacity(0.05)
+                    .ignoresSafeArea()
+                
+                ScrollView {
+                    LazyVStack(spacing: 8) {
+                        ForEach(Array(T.allCases), id: \.self) { action in
+                            MultipleSelectionRow(action: action, isSelected: viewState.contains(action)) {
+                                viewState.toggle(action)
+                            }
+                            .background(Color.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                            .shadow(color: .black.opacity(0.03), radius: 2, y: 1)
+                            .padding(.horizontal)
+                        }
+                    }
+                    .padding(.vertical)
                 }
             }
             .navigationTitle("行動を選択")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("キャンセル") {
-                        dismiss()
+                    Button(action: { dismiss() }) {
+                        Text("キャンセル")
+                            .foregroundColor(.blue)
                     }
                 }
+                
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("OK") {
-                        selectedActions = viewState.selectedActions
-                        dismiss()
+                    Button(action: {
+                        withAnimation {
+                            selectedActions = viewState.selectedActions
+                            dismiss()
+                        }
+                    }) {
+                        Text("完了")
+                            .fontWeight(.bold)
+                            .foregroundColor(.blue)
                     }
                 }
             }
@@ -32,4 +54,8 @@ struct ActionSelectionView<T: ActionType>: View {
             viewState.selectedActions = selectedActions
         }
     }
+}
+
+#Preview {
+    ActionSelectionView(selectedActions: .constant(Set<ChildActionType>()))
 }

--- a/ParentFeel/ParentFeel/View/ActionSelectionView/MultipleSelectionRow.swift
+++ b/ParentFeel/ParentFeel/View/ActionSelectionView/MultipleSelectionRow.swift
@@ -4,16 +4,39 @@ struct MultipleSelectionRow<T: ActionType>: View {
     var action: T
     var isSelected: Bool
     var actionTapped: () -> Void
-
+    
     var body: some View {
-        Button(action: actionTapped) {
-            HStack {
+        Button(action: {
+            withAnimation(.spring(response: 0.3)) {
+                actionTapped()
+            }
+        }) {
+            HStack(spacing: 16) {
                 Text(action.displayText)
+                    .font(.body)
+                    .foregroundColor(isSelected ? .blue : .primary)
+                
+                Spacer()
+                
                 if isSelected {
-                    Spacer()
-                    Image(systemName: "checkmark")
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.blue)
+                        .font(.system(size: 20))
+                        .symbolEffect(.bounce, value: isSelected)
+                } else {
+                    Image(systemName: "circle")
+                        .foregroundColor(.gray.opacity(0.5))
+                        .font(.system(size: 20))
                 }
             }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(isSelected ? Color.blue.opacity(0.1) : Color.clear)
+            )
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
     }
 }

--- a/ParentFeel/ParentFeel/View/EmotionInputView/EmotionInputView.swift
+++ b/ParentFeel/ParentFeel/View/EmotionInputView/EmotionInputView.swift
@@ -168,11 +168,11 @@ struct EmotionInputView: View {
                         .shadow(color: .blue.opacity(0.3), radius: 8, y: 4)
                 }
                 .padding(.horizontal)
-                .padding(.top)
+                .padding(.vertical)
                 .background(
                     Rectangle()
                         .fill(.background)
-                        .shadow(color: .black.opacity(0.1), radius: 8, y: -4)
+                        .shadow(color: .black.opacity(0.1), radius: 8, y: 8)
                 )
             }
             .ignoresSafeArea(.keyboard)

--- a/ParentFeel/ParentFeel/View/EmotionInputView/EmotionInputView.swift
+++ b/ParentFeel/ParentFeel/View/EmotionInputView/EmotionInputView.swift
@@ -12,129 +12,179 @@ struct EmotionInputView: View {
     }
 
     var body: some View {
-        VStack {
+        ZStack(alignment: .bottom) {
             ScrollView {
-                VStack(spacing: 16) {
-                    Text("起きた感情")
-                        .font(.headline)
-                        .padding(.horizontal)
-                    ForEach(EmotionCategory.allCases) { category in
-                        VStack(alignment: .leading) {
-                            Text(category.displayText)
-                                .font(.subheadline)
-                                .padding(.horizontal)
+                VStack(spacing: 24) {
+                    // 感情選択セクション
+                    VStack(spacing: 20) {
+                        Text("起きた感情")
+                            .font(.title2.bold())
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal)
+                        
+                        ForEach(EmotionCategory.allCases) { category in
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text(category.displayText)
+                                    .font(.headline)
+                                    .foregroundColor(.secondary)
+                                    .padding(.horizontal)
 
-                            LazyHGrid(rows: [GridItem(.fixed(80))], spacing: 16) {
-                                ForEach(category.emotions) { emotion in
-                                    Button(action: {
-                                        viewState.selectedEmotion = emotion
-                                    }) {
-                                        VStack {
-                                            Text(emotion.emoji)
-                                                .font(.largeTitle)
-                                                .padding(12)
-                                                .background(viewState.selectedEmotion == emotion ? Color.blue.opacity(0.8) : Color.gray.opacity(0.3))
-                                                .foregroundColor(.white)
-                                                .clipShape(Circle())
-                                                .overlay(
-                                                    Circle()
-                                                        .stroke(viewState.selectedEmotion == emotion ? Color.blue : Color.clear, lineWidth: 3)
-                                                )
-                                                .scaleEffect(viewState.selectedEmotion == emotion ? 1.1 : 1.0)
-                                                .animation(.spring(), value: viewState.selectedEmotion)
+                                ScrollView(.horizontal, showsIndicators: false) {
+                                    LazyHStack(spacing: 16) {
+                                        ForEach(category.emotions) { emotion in
+                                            Button(action: {
+                                                withAnimation(.spring(response: 0.3)) {
+                                                    viewState.selectedEmotion = emotion
+                                                }
+                                            }) {
+                                                VStack {
+                                                    Text(emotion.emoji)
+                                                        .font(.system(size: 40))
+                                                        .frame(width: 70, height: 70)
+                                                        .background(viewState.selectedEmotion == emotion ? Color.blue.opacity(0.8) : Color.gray.opacity(0.1))
+                                                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                                                        .overlay(
+                                                            RoundedRectangle(cornerRadius: 16)
+                                                                .stroke(viewState.selectedEmotion == emotion ? Color.blue : Color.clear, lineWidth: 3)
+                                                        )
+                                                        .shadow(color: viewState.selectedEmotion == emotion ? .blue.opacity(0.3) : .clear, radius: 8)
 
-                                            Text(emotion.displayText)
-                                                .font(.caption)
-                                                .foregroundColor(viewState.selectedEmotion == emotion ? .blue : .black)
+                                                    Text(emotion.displayText)
+                                                        .font(.subheadline)
+                                                        .foregroundColor(viewState.selectedEmotion == emotion ? .blue : .primary)
+                                                }
+                                                .padding(4) // 選択時の拡大に対するマージン
+                                            }
+                                            .scaleEffect(viewState.selectedEmotion == emotion ? 1.05 : 1.0)
                                         }
                                     }
+                                    .padding(.horizontal)
                                 }
                             }
-                            .padding(.horizontal)
                         }
                     }
-                }
-
-                // 子どもの行動選択
-                VStack(spacing: 8) {
-                    Text("子どもの行動(任意)")
-                        .font(.headline)
-                    Button("選択する") {
-                        viewState.isChildActionModalPresented = true
-                    }
-                    .padding(10)
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .font(.headline)
-                    .cornerRadius(20)
-                    .shadow(radius: 2)
-                    .sheet(isPresented: $viewState.isChildActionModalPresented) {
-                        ActionSelectionView(selectedActions: $viewState.selectedChildActions)
-                    }
-                    Text(viewState.selectedChildActions.map { $0.displayText }.joined(separator: ", "))
-                        .font(.caption)
-                }
-                .padding(.vertical, 8)
-
-                // 自分の行動選択
-                VStack(spacing: 8) {
-                    Text("自分の行動(任意)")
-                        .font(.headline)
-                    Button("選択する") {
-                        viewState.isParentActionModalPresented = true
-                    }
-                    .padding(10)
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .font(.headline)
-                    .cornerRadius(20)
-                    .shadow(radius: 2)
-                    .sheet(isPresented: $viewState.isParentActionModalPresented) {
-                        ActionSelectionView(selectedActions: $viewState.selectedParentActions)
-                    }
-                    Text(viewState.selectedParentActions.map { $0.displayText }.joined(separator: ", "))
-                        .font(.caption)
-                }
-                .padding(.vertical, 8)
-
-
-                // メモ欄
-                VStack(alignment: .leading) {
-                    Text("メモ(任意)")
-                        .font(.headline)
+                    .padding(.vertical)
+                    
+                    // 行動選択セクション
+                    VStack(spacing: 24) {
+                        // 子どもの行動選択
+                        VStack(spacing: 12) {
+                            Text("子どもの行動")
+                                .font(.title2.bold())
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            
+                            Button(action: {
+                                viewState.isChildActionModalPresented = true
+                            }) {
+                                HStack {
+                                    Image(systemName: "plus.circle.fill")
+                                    Text(viewState.selectedChildActions.isEmpty ? "選択する" : "変更する")
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.blue.opacity(0.1))
+                                .foregroundColor(.blue)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                            }
+                            
+                            if !viewState.selectedChildActions.isEmpty {
+                                Text(viewState.selectedChildActions.map { $0.displayText }.joined(separator: "、"))
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
                         .padding(.horizontal)
-
-                    ZStack(alignment: .topLeading) {
-                        if viewState.notes.isEmpty {
-                            Text("ここにメモを入力")
-                                .foregroundColor(.gray)
-                                .padding(10)
+                        
+                        // 自分の行動選択
+                        VStack(spacing: 12) {
+                            Text("自分の行動")
+                                .font(.title2.bold())
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            
+                            Button(action: {
+                                viewState.isParentActionModalPresented = true
+                            }) {
+                                HStack {
+                                    Image(systemName: "plus.circle.fill")
+                                    Text(viewState.selectedParentActions.isEmpty ? "選択する" : "変更する")
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.blue.opacity(0.1))
+                                .foregroundColor(.blue)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                            }
+                            
+                            if !viewState.selectedParentActions.isEmpty {
+                                Text(viewState.selectedParentActions.map { $0.displayText }.joined(separator: "、"))
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
                         }
+                        .padding(.horizontal)
+                    }
 
-                        TextEditor(text: $viewState.notes)
-                            .frame(height: 100)
-                            .padding(10)
-                            .background(Color(UIColor.systemGray6))
-                            .cornerRadius(8)
+                    // メモ欄
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("メモ")
+                            .font(.title2.bold())
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        ZStack(alignment: .topLeading) {
+                            if viewState.notes.isEmpty {
+                                Text("ここにメモを入力")
+                                    .foregroundColor(.secondary)
+                                    .padding(.top, 8)
+                                    .padding(.leading, 5)
+                            }
+
+                            TextEditor(text: $viewState.notes)
+                                .frame(minHeight: 100)
+                                .scrollContentBackground(.hidden)
+                                .background(Color.gray.opacity(0.1))
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
                     }
                     .padding(.horizontal)
+                    
+                    // 保存ボタンの下のスペース
+                    Color.clear
+                        .frame(height: 100) // 固定保存ボタンの高さ分のスペース
                 }
             }
-
-            // 保存ボタン
-            Button(action: viewState.saveEmotion) {
-                Text("保存")
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .font(.headline)
-                    .cornerRadius(20)
-                    .shadow(radius: 2)
+            
+            // 固定保存ボタン
+            VStack(spacing: 0) {
+                Button(action: viewState.saveEmotion) {
+                    Text("保存")
+                        .fontWeight(.bold)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                        .shadow(color: .blue.opacity(0.3), radius: 8, y: 4)
+                }
+                .padding(.horizontal)
+                .padding(.top)
+                .background(
+                    Rectangle()
+                        .fill(.background)
+                        .shadow(color: .black.opacity(0.1), radius: 8, y: -4)
+                )
             }
-            .padding()
+            .ignoresSafeArea(.keyboard)
+            .ignoresSafeArea(.container, edges: .bottom)
         }
         .navigationTitle("感情記録")
+        .sheet(isPresented: $viewState.isChildActionModalPresented) {
+            ActionSelectionView(selectedActions: $viewState.selectedChildActions)
+        }
+        .sheet(isPresented: $viewState.isParentActionModalPresented) {
+            ActionSelectionView(selectedActions: $viewState.selectedParentActions)
+        }
         .onAppear {
             viewState.setModelContext(modelContext)
         }


### PR DESCRIPTION
## 概要

感情入力画面（EmotionInputView）とその関連コンポーネントのデザインを改善し、より使いやすく視覚的に魅力的なUIに更新しました。

## 変更内容

- EmotionInputViewのデザイン改善
  - 感情選択ボタンのマージンを追加し、選択時の拡大表示で見切れないように修正
  - 保存ボタンを画面下部に固定表示し、SafeAreaInsetまで表示するように変更
  - ボタンやテキストエリアのデザインを改善

- ActionSelectionViewのデザイン改善
  - リスト項目のデザインを視覚的に魅力的に更新
  - 選択状態の表示をより明確に
  - アニメーションの追加
  - 全体的なスペーシングとパディングの調整

## レビュアーへの補足情報

- 実装されている動作は変更せず、UIデザインの改善のみを行いました
- HomeViewのデザインテイストを参考に、一貫性のあるデザインに更新しています
- ビルドを実行し、コンパイルエラーがないことを確認済みです