### PR TITLE
自己振り返り機能の追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,10 @@
 * SVVSでは、ViewのアクションがViewStateを通じてStoreに伝達されます。StoreはAPIやDBと通信し、シングルトンでデータを保持します。
 * Storeのデータ変更はViewStateを介してViewに反映され、単方向データフローを実現します。
 
+# テストコードについての補足
+
+* ViewStateのテストコードはstructの定義の上に`@MainActor`が必要です。
+
 # 動作確認について
 
 * ビルドは以下のコマンドで行ってください。

--- a/ParentFeel/Localizable.xcstrings
+++ b/ParentFeel/Localizable.xcstrings
@@ -62,6 +62,46 @@
         }
       }
     },
+    "ここに対応方法を入力" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter your desired response here"
+          }
+        }
+      }
+    },
+    "ここに感じ方を入力" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter your feelings here"
+          }
+        }
+      }
+    },
+    "ここに過去の経験を入力" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter past experiences here"
+          }
+        }
+      }
+    },
+    "この感情を引き起こした自分の過去の経験は？" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Past experiences that triggered this emotion?"
+          }
+        }
+      }
+    },
     "サポートする" : {
       "localizations" : {
         "en" : {
@@ -78,6 +118,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sulking"
+          }
+        }
+      }
+    },
+    "すべて" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All"
+          }
+        }
+      }
+    },
+    "その経験をどう感じていた？" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How did you feel about that experience?"
           }
         }
       }
@@ -102,12 +162,53 @@
         }
       }
     },
+    "ニュートラル" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neutral"
+          }
+        }
+      }
+    },
+    "ネガティブ" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Negative"
+          }
+        }
+      }
+    },
     "ふざける" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Joking around"
+          }
+        }
+      }
+    },
+    "ポジティブ" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Positive"
+          }
+        }
+      }
+    },
+    "ポジティブ / ネガティブ" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Positive / Negative"
           }
         }
       }
@@ -173,6 +274,16 @@
         }
       }
     },
+    "今の子どもにはどう対応したい？" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How would you like to respond to your child now?"
+          }
+        }
+      }
+    },
     "保存" : {
       "localizations" : {
         "en" : {
@@ -209,6 +320,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Being kind"
+          }
+        }
+      }
+    },
+    "最近使用" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recent"
           }
         }
       }
@@ -348,7 +469,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Child’s behavior"
+            "value" : "Child's behavior"
           }
         }
       }
@@ -359,7 +480,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Child’s behavior (Optional)"
+            "value" : "Child's behavior (Optional)"
           }
         }
       }
@@ -765,6 +886,16 @@
         }
       }
     },
+    "自己振り返り" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Self-reflection"
+          }
+        }
+      }
+    },
     "興奮" : {
       "localizations" : {
         "en" : {
@@ -978,56 +1109,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Concentrating"
-          }
-        }
-      }
-    },
-    "すべて" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All"
-          }
-        }
-      }
-    },
-    "ニュートラル" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neutral"
-          }
-        }
-      }
-    },
-    "ポジティブ" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Positive"
-          }
-        }
-      }
-    },
-    "ネガティブ" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Negative"
-          }
-        }
-      }
-    },
-    "最近使用" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recent"
           }
         }
       }

--- a/ParentFeel/ParentFeel.xcodeproj/project.pbxproj
+++ b/ParentFeel/ParentFeel.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				OTHER_LDFLAGS = (
 					"-Xlinker",
 					"-interposable",
@@ -494,7 +494,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.hiray.ParentFeel;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ParentFeel/ParentFeel/SwiftData/Emotion.swift
+++ b/ParentFeel/ParentFeel/SwiftData/Emotion.swift
@@ -9,13 +9,22 @@ final class Emotion: Identifiable {
     var parentActions: [ParentActionType]
     var notes: String
     var timestamp: Date
+    var pastExperience: String = ""
+    var pastExperienceFeeling: String = ""
+    var pastExperienceSentiment: String = "" // "positive", "negative", or empty
+    var desiredResponse: String = ""
 
-    init(emotionType: EmotionType, childActions: [ChildActionType], parentActions: [ParentActionType], notes: String) {
+    init(emotionType: EmotionType, childActions: [ChildActionType], parentActions: [ParentActionType], notes: String, 
+         pastExperience: String = "", pastExperienceFeeling: String = "", pastExperienceSentiment: String = "", desiredResponse: String = "") {
         self.id = UUID()
         self.emotionType = emotionType
         self.childActions = childActions
         self.parentActions = parentActions
         self.notes = notes
         self.timestamp = Date()
+        self.pastExperience = pastExperience
+        self.pastExperienceFeeling = pastExperienceFeeling
+        self.pastExperienceSentiment = pastExperienceSentiment
+        self.desiredResponse = desiredResponse
     }
 }

--- a/ParentFeel/ParentFeel/View/EmotionInputView/EmotionInputView.swift
+++ b/ParentFeel/ParentFeel/View/EmotionInputView/EmotionInputView.swift
@@ -125,6 +125,119 @@ struct EmotionInputView: View {
                         }
                         .padding(.horizontal)
                     }
+                    
+                    // 自己振り返りセクション
+                    VStack(spacing: 24) {
+                        Text("自己振り返り")
+                            .font(.title2.bold())
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal)
+                        
+                        // 過去の経験
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("この感情を引き起こした自分の過去の経験は？")
+                                .font(.headline)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+
+                            ZStack(alignment: .topLeading) {
+                                if viewState.pastExperience.isEmpty {
+                                    Text("ここに過去の経験を入力")
+                                        .foregroundColor(.secondary)
+                                        .padding(.top, 8)
+                                        .padding(.leading, 5)
+                                }
+
+                                TextEditor(text: $viewState.pastExperience)
+                                    .frame(minHeight: 100)
+                                    .scrollContentBackground(.hidden)
+                                    .background(Color.gray.opacity(0.1))
+                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                            }
+                        }
+                        .padding(.horizontal)
+                        
+                        // その経験の感じ方
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("その経験をどう感じていた？")
+                                .font(.headline)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            
+                            // ポジティブ/ネガティブの選択
+                            HStack(spacing: 16) {
+                                Button(action: {
+                                    viewState.pastExperienceSentiment = "positive"
+                                }) {
+                                    HStack {
+                                        Image(systemName: viewState.pastExperienceSentiment == "positive" ? "checkmark.circle.fill" : "circle")
+                                            .foregroundColor(viewState.pastExperienceSentiment == "positive" ? .blue : .gray)
+                                        Text("ポジティブ")
+                                            .foregroundColor(viewState.pastExperienceSentiment == "positive" ? .blue : .primary)
+                                    }
+                                    .padding(.vertical, 8)
+                                    .padding(.horizontal, 12)
+                                    .background(viewState.pastExperienceSentiment == "positive" ? Color.blue.opacity(0.1) : Color.clear)
+                                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                                }
+                                
+                                Button(action: {
+                                    viewState.pastExperienceSentiment = "negative"
+                                }) {
+                                    HStack {
+                                        Image(systemName: viewState.pastExperienceSentiment == "negative" ? "checkmark.circle.fill" : "circle")
+                                            .foregroundColor(viewState.pastExperienceSentiment == "negative" ? .blue : .gray)
+                                        Text("ネガティブ")
+                                            .foregroundColor(viewState.pastExperienceSentiment == "negative" ? .blue : .primary)
+                                    }
+                                    .padding(.vertical, 8)
+                                    .padding(.horizontal, 12)
+                                    .background(viewState.pastExperienceSentiment == "negative" ? Color.blue.opacity(0.1) : Color.clear)
+                                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                                }
+                                
+                                Spacer()
+                            }
+                            
+                            ZStack(alignment: .topLeading) {
+                                if viewState.pastExperienceFeeling.isEmpty {
+                                    Text("ここに感じ方を入力")
+                                        .foregroundColor(.secondary)
+                                        .padding(.top, 8)
+                                        .padding(.leading, 5)
+                                }
+
+                                TextEditor(text: $viewState.pastExperienceFeeling)
+                                    .frame(minHeight: 100)
+                                    .scrollContentBackground(.hidden)
+                                    .background(Color.gray.opacity(0.1))
+                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                            }
+                        }
+                        .padding(.horizontal)
+                        
+                        // 子どもへの対応方法
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("今の子どもにはどう対応したい？")
+                                .font(.headline)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+
+                            ZStack(alignment: .topLeading) {
+                                if viewState.desiredResponse.isEmpty {
+                                    Text("ここに対応方法を入力")
+                                        .foregroundColor(.secondary)
+                                        .padding(.top, 8)
+                                        .padding(.leading, 5)
+                                }
+
+                                TextEditor(text: $viewState.desiredResponse)
+                                    .frame(minHeight: 100)
+                                    .scrollContentBackground(.hidden)
+                                    .background(Color.gray.opacity(0.1))
+                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+                    .padding(.vertical)
 
                     // メモ欄
                     VStack(alignment: .leading, spacing: 12) {

--- a/ParentFeel/ParentFeel/View/EmotionInputView/EmotionInputViewState.swift
+++ b/ParentFeel/ParentFeel/View/EmotionInputView/EmotionInputViewState.swift
@@ -11,11 +11,17 @@ class EmotionInputViewState: ObservableObject {
     @Published var notes: String
     @Published var isChildActionModalPresented = false
     @Published var isParentActionModalPresented = false
-
+    
+    // New properties for self-reflection
+    @Published var pastExperience: String
+    @Published var pastExperienceFeeling: String
+    @Published var pastExperienceSentiment: String // "positive", "negative", or empty
+    @Published var desiredResponse: String
+    
     private var modelContext: ModelContext?
     @Binding var path: NavigationPath
     private var emotion: Emotion?
-
+    
     init(emotion: Emotion? = nil, path: Binding<NavigationPath>) {
         self._path = path
         if let emotion = emotion {
@@ -24,31 +30,54 @@ class EmotionInputViewState: ObservableObject {
             self.selectedParentActions = Set(emotion.parentActions)
             self.notes = emotion.notes
             self.emotion = emotion
+            
+            // Initialize new properties with existing values if editing
+            self.pastExperience = emotion.pastExperience
+            self.pastExperienceFeeling = emotion.pastExperienceFeeling
+            self.pastExperienceSentiment = emotion.pastExperienceSentiment
+            self.desiredResponse = emotion.desiredResponse
         } else {
             self.selectedEmotion = .affection
             self.selectedChildActions = []
             self.selectedParentActions = []
             self.notes = ""
+            
+            // Initialize new properties as empty if creating new
+            self.pastExperience = ""
+            self.pastExperienceFeeling = ""
+            self.pastExperienceSentiment = ""
+            self.desiredResponse = ""
         }
     }
-
+    
     func setModelContext(_ context: ModelContext) {
         self.modelContext = context
     }
-
+    
     func saveEmotion() {
         if let emotion = emotion {
             emotion.emotionType = selectedEmotion
             emotion.childActions = selectedChildActions.compactMap { ChildActionType(rawValue: $0.rawValue) }
             emotion.parentActions = selectedParentActions.compactMap { ParentActionType(rawValue: $0.rawValue) }
             emotion.notes = notes
+            
+            // Update new fields
+            emotion.pastExperience = pastExperience
+            emotion.pastExperienceFeeling = pastExperienceFeeling
+            emotion.pastExperienceSentiment = pastExperienceSentiment
+            emotion.desiredResponse = desiredResponse
+            
             try? modelContext?.save()
         } else {
             let newEmotion = Emotion(
                 emotionType: selectedEmotion,
                 childActions: selectedChildActions.compactMap { ChildActionType(rawValue: $0.rawValue) },
                 parentActions: selectedParentActions.compactMap { ParentActionType(rawValue: $0.rawValue) },
-                notes: notes
+                notes: notes,
+                pastExperience: pastExperience,
+                pastExperienceFeeling: pastExperienceFeeling,
+                pastExperienceSentiment: pastExperienceSentiment,
+                desiredResponse: desiredResponse
             )
             modelContext?.insert(newEmotion)
         }

--- a/ParentFeel/ParentFeel/View/EmptionDetailView/EmotionDetailView.swift
+++ b/ParentFeel/ParentFeel/View/EmptionDetailView/EmotionDetailView.swift
@@ -53,6 +53,65 @@ struct EmotionDetailView: View {
                         .fill(Color.gray.opacity(0.05))
                 )
                 
+                // 自己振り返りセクション
+                if !viewState.pastExperienceText.isEmpty || !viewState.pastExperienceFeelingText.isEmpty || !viewState.desiredResponseText.isEmpty {
+                    VStack(alignment: .leading, spacing: 16) {
+                        if !viewState.pastExperienceText.isEmpty {
+                            detailRow(
+                                title: String(localized: "この感情を引き起こした自分の過去の経験は？"),
+                                content: viewState.pastExperienceText,
+                                systemImage: "clock.arrow.circlepath",
+                                multiline: true
+                            )
+                        }
+                        
+                        if !viewState.pastExperienceFeelingText.isEmpty || !viewState.pastExperienceSentimentText.isEmpty {
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack(spacing: 8) {
+                                    Image(systemName: "face.smiling")
+                                        .foregroundColor(.blue)
+                                    Text("その経験をどう感じていた？")
+                                        .font(.headline)
+                                        .foregroundColor(.secondary)
+                                }
+                                
+                                if !viewState.pastExperienceSentimentText.isEmpty {
+                                    Text(viewState.pastExperienceSentimentText)
+                                        .font(.subheadline)
+                                        .padding(.vertical, 4)
+                                        .padding(.horizontal, 8)
+                                        .background(
+                                            RoundedRectangle(cornerRadius: 8)
+                                                .fill(Color.blue.opacity(0.1))
+                                        )
+                                }
+                                
+                                if !viewState.pastExperienceFeelingText.isEmpty {
+                                    Text(viewState.pastExperienceFeelingText)
+                                        .font(.body)
+                                        .foregroundColor(.primary)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
+                        }
+                        
+                        if !viewState.desiredResponseText.isEmpty {
+                            detailRow(
+                                title: String(localized: "今の子どもにはどう対応したい？"),
+                                content: viewState.desiredResponseText,
+                                systemImage: "hand.raised",
+                                multiline: true
+                            )
+                        }
+                    }
+                    .padding(20)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(Color.purple.opacity(0.05))
+                    )
+                }
+                
                 VStack(alignment: .leading, spacing: 16) {
                     if !viewState.notesText.isEmpty {
                         detailRow(

--- a/ParentFeel/ParentFeel/View/EmptionDetailView/EmotionDetailViewState.swift
+++ b/ParentFeel/ParentFeel/View/EmptionDetailView/EmotionDetailViewState.swift
@@ -21,6 +21,29 @@ class EmotionDetailViewState: ObservableObject {
         emotion.parentActions.map { $0.displayText }.joined(separator: ", ")
     }
 
+    var pastExperienceText: String {
+        emotion.pastExperience
+    }
+
+    var pastExperienceFeelingText: String {
+        emotion.pastExperienceFeeling
+    }
+
+    var pastExperienceSentimentText: String {
+        switch emotion.pastExperienceSentiment {
+        case "positive":
+            return String(localized: "ポジティブ")
+        case "negative":
+            return String(localized: "ネガティブ")
+        default:
+            return ""
+        }
+    }
+
+    var desiredResponseText: String {
+        emotion.desiredResponse
+    }
+
     var notesText: String {
         emotion.notes
     }

--- a/ParentFeel/ParentFeelTests/EmotionDetailViewStateTests.swift
+++ b/ParentFeel/ParentFeelTests/EmotionDetailViewStateTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+import Testing
+import SwiftUI
+@testable import ParentFeel
+
+@MainActor
+@Suite("EmotionDetailViewState Tests")
+struct EmotionDetailViewStateTests {
+    
+    // テスト用のEmotionオブジェクト
+    let testEmotion = Emotion(
+        emotionType: .joy,
+        childActions: [.crying, .laughing],
+        parentActions: [.hugging, .listening],
+        notes: "テストメモ",
+        pastExperience: "子どもの頃の体験",
+        pastExperienceFeeling: "楽しかった",
+        pastExperienceSentiment: "positive",
+        desiredResponse: "優しく対応したい"
+    )
+    
+    let emptyEmotion = Emotion(
+        emotionType: .fear,
+        childActions: [],
+        parentActions: [],
+        notes: "",
+        pastExperience: "",
+        pastExperienceFeeling: "",
+        pastExperienceSentiment: "",
+        desiredResponse: ""
+    )
+    
+    @Test("EmotionDetailViewState - 自己振り返り関連のプロパティが正しく取得される")
+    func testSelfReflectionProperties() throws {
+        // 準備
+        let viewState = EmotionDetailViewState(emotion: testEmotion)
+        
+        // 検証 - 各プロパティが正しい値を返すことを確認
+        #expect(viewState.pastExperienceText == "子どもの頃の体験")
+        #expect(viewState.pastExperienceFeelingText == "楽しかった")
+        #expect(viewState.pastExperienceSentimentText == "ポジティブ")
+        #expect(viewState.desiredResponseText == "優しく対応したい")
+    }
+    
+    @Test("EmotionDetailViewState - pastExperienceSentimentText が正しい文字列を返す")
+    func testPastExperienceSentimentText() throws {
+        // 準備 - 異なるsentiment値でテスト
+        let positiveEmotion = createEmotionWithSentiment("positive")
+        let negativeEmotion = createEmotionWithSentiment("negative")
+        let emptyEmotion = createEmotionWithSentiment("")
+        
+        let positiveState = EmotionDetailViewState(emotion: positiveEmotion)
+        let negativeState = EmotionDetailViewState(emotion: negativeEmotion)
+        let emptyState = EmotionDetailViewState(emotion: emptyEmotion)
+        
+        // 検証
+        #expect(positiveState.pastExperienceSentimentText == "ポジティブ")
+        #expect(negativeState.pastExperienceSentimentText == "ネガティブ")
+        #expect(emptyState.pastExperienceSentimentText == "")
+    }
+    
+    @Test("EmotionDetailViewState - 既存フィールド（emotionTypeText, notesText など）も正しく取得される")
+    func testExistingProperties() throws {
+        // 準備
+        let viewState = EmotionDetailViewState(emotion: testEmotion)
+        
+        // 検証 - 既存のプロパティも正しい値を返すことを確認
+        // EmotionTypeのdisplayTextを直接使用
+        #expect(viewState.emotionTypeText.contains(testEmotion.emotionType.emoji))
+        #expect(viewState.emotionTypeText.contains(testEmotion.emotionType.displayText))
+        #expect(viewState.childActionsText.contains(testEmotion.childActions[0].displayText))
+        #expect(viewState.childActionsText.contains(testEmotion.childActions[1].displayText))
+        #expect(viewState.parentActionsText.contains(testEmotion.parentActions[0].displayText))
+        #expect(viewState.parentActionsText.contains(testEmotion.parentActions[1].displayText))
+        #expect(viewState.notesText == "テストメモ")
+    }
+    
+    @Test("EmotionDetailViewState - 空の値が正しく処理される")
+    func testEmptyValues() throws {
+        // 準備
+        let viewState = EmotionDetailViewState(emotion: emptyEmotion)
+        
+        // 検証 - 空の値が正しく処理されることを確認
+        #expect(viewState.pastExperienceText.isEmpty)
+        #expect(viewState.pastExperienceFeelingText.isEmpty)
+        #expect(viewState.pastExperienceSentimentText.isEmpty)
+        #expect(viewState.desiredResponseText.isEmpty)
+        #expect(viewState.notesText.isEmpty)
+    }
+    
+    // テスト用のヘルパーメソッド
+    func createEmotionWithSentiment(_ sentiment: String) -> Emotion {
+        return Emotion(
+            emotionType: .joy,
+            childActions: [],
+            parentActions: [],
+            notes: "",
+            pastExperience: "",
+            pastExperienceFeeling: "",
+            pastExperienceSentiment: sentiment,
+            desiredResponse: ""
+        )
+    }
+}

--- a/ParentFeel/ParentFeelTests/EmotionInputViewStateTests.swift
+++ b/ParentFeel/ParentFeelTests/EmotionInputViewStateTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import Testing
+import SwiftUI
+import SwiftData
+@testable import ParentFeel
+
+@MainActor
+@Suite("EmotionInputViewState Tests")
+struct EmotionInputViewStateTests {
+    
+    // シンプルなテスト用のEmotionオブジェクト
+    func createTestEmotion() -> Emotion {
+        return Emotion(
+            emotionType: .joy,
+            childActions: [.crying, .laughing],
+            parentActions: [.hugging, .listening],
+            notes: "テストメモ",
+            pastExperience: "子どもの頃の体験",
+            pastExperienceFeeling: "楽しかった",
+            pastExperienceSentiment: "positive",
+            desiredResponse: "優しく対応したい"
+        )
+    }
+    
+    @Test("初期化時に正しい値がセットされる - 新規作成の場合")
+    func testInitDefaultValues() throws {
+        // 実行
+        let path = Binding.constant(NavigationPath())
+        let viewState = EmotionInputViewState(emotion: nil, path: path)
+        
+        // 検証 - デフォルト値が正しくセットされていることを確認
+        #expect(viewState.selectedEmotion == .affection)
+        #expect(viewState.selectedChildActions.isEmpty)
+        #expect(viewState.selectedParentActions.isEmpty)
+        #expect(viewState.notes == "")
+        #expect(viewState.pastExperience == "")
+        #expect(viewState.pastExperienceFeeling == "")
+        #expect(viewState.pastExperienceSentiment == "")
+        #expect(viewState.desiredResponse == "")
+    }
+    
+    @Test("初期化時に正しい値がセットされる - 既存の感情を編集する場合")
+    func testInitWithExistingEmotion() throws {
+        // 準備
+        let testEmotion = createTestEmotion()
+        let path = Binding.constant(NavigationPath())
+        
+        // 実行
+        let viewState = EmotionInputViewState(emotion: testEmotion, path: path)
+        
+        // 検証 - 既存の感情の値が正しくセットされていることを確認
+        #expect(viewState.selectedEmotion == .joy)
+        #expect(viewState.selectedChildActions.contains(.crying))
+        #expect(viewState.selectedChildActions.contains(.laughing))
+        #expect(viewState.selectedParentActions.contains(.hugging))
+        #expect(viewState.selectedParentActions.contains(.listening))
+        #expect(viewState.notes == "テストメモ")
+        #expect(viewState.pastExperience == "子どもの頃の体験")
+        #expect(viewState.pastExperienceFeeling == "楽しかった")
+        #expect(viewState.pastExperienceSentiment == "positive")
+        #expect(viewState.desiredResponse == "優しく対応したい")
+    }
+    
+    @Test("自己振り返りフィールドが正しく処理される")
+    func testSelfReflectionFields() throws {
+        // 準備
+        let path = Binding.constant(NavigationPath())
+        let viewState = EmotionInputViewState(path: path)
+        
+        // 値を設定
+        viewState.pastExperience = "新しい過去の経験"
+        viewState.pastExperienceFeeling = "新しい感じ方"
+        viewState.pastExperienceSentiment = "negative"
+        viewState.desiredResponse = "新しい対応方法"
+        
+        // 検証
+        #expect(viewState.pastExperience == "新しい過去の経験")
+        #expect(viewState.pastExperienceFeeling == "新しい感じ方")
+        #expect(viewState.pastExperienceSentiment == "negative")
+        #expect(viewState.desiredResponse == "新しい対応方法")
+    }
+}


### PR DESCRIPTION
## 概要

感情入力画面に自己振り返り機能を追加しました。
ユーザーは感情を記録する際に、過去の経験、その経験の感じ方、および子どもへの対応方法を記録できるようになります。

## 変更内容

- Emotionモデルに自己振り返り用のフィールドを追加
  - pastExperience: 過去の経験
  - pastExperienceFeeling: 経験の感じ方
  - pastExperienceSentiment: 感情の種類（ポジティブ/ネガティブ）
  - desiredResponse: 子どもへの希望する対応方法
- 感情入力画面に自己振り返りセクションを追加
- 感情詳細画面を更新して自己振り返りの内容を表示
- 新しいテキストの多言語対応（日本語・英語）
- アプリバージョンを1.5に更新

## レビュアーへの補足情報

自己振り返り機能はオプショナルで、ユーザーは必要に応じて入力できます。
入力されていない場合は詳細画面でもセクションは表示されません。

## 手動でテストが必要な箇所

- [x] 感情入力画面で自己振り返りセクションに入力し、保存できることを確認
- [x] ポジティブ/ネガティブの選択が正しく保存されることを確認
- [x] 自己振り返りの内容が感情詳細画面で正しく表示されることを確認
- [x] 既存の感情を編集する際に、自己振り返りの内容が正しく表示されることを確認
- [x] 英語環境で全ての文言が正しく表示されることを確認
