### PR TITLE
月別のセクションヘッダー付きのリスト表示に変更

### DIFF
--- a/ParentFeel/ParentFeel.xcodeproj/project.pbxproj
+++ b/ParentFeel/ParentFeel.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				OTHER_LDFLAGS = (
 					"-Xlinker",
 					"-interposable",
@@ -494,7 +494,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.6;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.hiray.ParentFeel;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ParentFeel/ParentFeel/View/HomeView/HomeView.swift
+++ b/ParentFeel/ParentFeel/View/HomeView/HomeView.swift
@@ -24,13 +24,21 @@ struct HomeView: View {
             Group {
                 if viewState.isEditing {
                     List {
-                        ForEach(emotions) { emotion in
-                            EmotionCard(emotion: emotion)
-                                .onTapGesture {
-                                    viewState.path.append(Screen.detail(emotion))
+                        ForEach(viewState.groupEmotionsByMonth(emotions)) { section in
+                            Section(
+                                header: Text(section.month.formatted(.dateTime.year().month(.wide)))
+                                    .font(.headline)
+                                    .foregroundStyle(.primary)
+                            ) {
+                                ForEach(section.emotions) { emotion in
+                                    EmotionCard(emotion: emotion)
+                                        .onTapGesture {
+                                            viewState.path.append(Screen.detail(emotion))
+                                        }
+                                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                                        .listRowSeparator(.hidden)
                                 }
-                                .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
-                                .listRowSeparator(.hidden)
+                            }
                         }
                         .onDelete { indexSet in
                             viewState.deleteEmotions(emotions: emotions, offsets: indexSet)
@@ -41,20 +49,33 @@ struct HomeView: View {
                     
                 } else {
                     ScrollView {
-                        LazyVStack(spacing: 16) {
-                            ForEach(emotions) { emotion in
-                                EmotionCard(emotion: emotion)
-                                    .onTapGesture {
-                                        viewState.path.append(Screen.detail(emotion))
+                        LazyVStack(spacing: 16, pinnedViews: .sectionHeaders) {
+                            ForEach(viewState.groupEmotionsByMonth(emotions)) { section in
+                                Section(
+                                    header: HStack {
+                                        Text(section.month.formatted(.dateTime.year().month(.wide)))
+                                            .font(.headline)
+                                            .padding(.horizontal)
+                                            .padding(.vertical, 8)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                            .background(.background)
                                     }
-                                    .transition(.scale.combined(with: .opacity))
-                                    .contextMenu {
-                                        Button(role: .destructive) {
-                                            viewState.deleteEmotion(emotion: emotion)
-                                        } label: {
-                                            Label("削除", systemImage: "trash")
-                                        }
+                                ) {
+                                    ForEach(section.emotions) { emotion in
+                                        EmotionCard(emotion: emotion)
+                                            .onTapGesture {
+                                                viewState.path.append(Screen.detail(emotion))
+                                            }
+                                            .transition(.scale.combined(with: .opacity))
+                                            .contextMenu {
+                                                Button(role: .destructive) {
+                                                    viewState.deleteEmotion(emotion: emotion)
+                                                } label: {
+                                                    Label("削除", systemImage: "trash")
+                                                }
+                                            }
                                     }
+                                }
                             }
                             .padding(.horizontal)
                         }

--- a/ParentFeel/ParentFeel/View/HomeView/HomeViewState.swift
+++ b/ParentFeel/ParentFeel/View/HomeView/HomeViewState.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 import SwiftData
 
+struct MonthSection: Identifiable {
+    let id: String
+    let month: Date
+    let emotions: [Emotion]
+}
+
+@MainActor
 class HomeViewState: ObservableObject {
     @Published var path = NavigationPath()
     @Published var isEditing = false
@@ -27,5 +34,27 @@ class HomeViewState: ObservableObject {
         withAnimation {
             modelContext.delete(emotion)
         }
+    }
+    
+    func groupEmotionsByMonth(_ emotions: [Emotion]) -> [MonthSection] {
+        let calendar = Calendar.current
+        let grouped = Dictionary(grouping: emotions) { emotion in
+            calendar.startOfMonth(for: emotion.timestamp)
+        }
+        
+        return grouped.map { (date, emotions) in
+            MonthSection(
+                id: date.formatted(.dateTime.year().month()),
+                month: date,
+                emotions: emotions
+            )
+        }.sorted { $0.month > $1.month }
+    }
+}
+
+private extension Calendar {
+    func startOfMonth(for date: Date) -> Date {
+        let components = dateComponents([.year, .month], from: date)
+        return self.date(from: components) ?? date
     }
 }

--- a/ParentFeel/ParentFeelTests/HomeViewStateTests.swift
+++ b/ParentFeel/ParentFeelTests/HomeViewStateTests.swift
@@ -12,13 +12,13 @@ class ContextRecorder {
     }
 }
 
+@MainActor
 @Suite("HomeViewState Tests")
 struct HomeViewStateTests {
     
     // テストヘルパー関数
-    @MainActor
     private func createTestContext() throws -> (ModelContext, ContextRecorder) {
-        let container = try ModelContainer(for: Emotion.self)
+        let container = try ModelContainer(for: Emotion.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
         let context = container.mainContext
         let recorder = ContextRecorder()
         return (context, recorder)
@@ -27,7 +27,7 @@ struct HomeViewStateTests {
     @Test("isEditing - defaults to false")
     func testIsEditingDefaultValue() async throws {
         // 準備
-        let (context, _) = try await MainActor.run { try createTestContext() }
+        let (context, _) = try createTestContext()
         
         // 実行
         let viewState = HomeViewState(modelContext: context)
@@ -39,8 +39,8 @@ struct HomeViewStateTests {
     @Test("updateModelContext - updates the model context")
     func testUpdateModelContext() async throws {
         // 準備
-        let (context1, _) = try await MainActor.run { try createTestContext() }
-        let (context2, _) = try await MainActor.run { try createTestContext() }
+        let (context1, _) = try createTestContext()
+        let (context2, _) = try createTestContext()
         let viewState = HomeViewState(modelContext: context1)
         
         // 実行
@@ -53,12 +53,12 @@ struct HomeViewStateTests {
     @Test("deleteEmotion - deletes a single emotion")
     func testDeleteEmotion() async throws {
         // 準備
-        let (context, recorder) = try await MainActor.run { try createTestContext() }
+        let (context, recorder) = try createTestContext()
         let viewState = HomeViewState(modelContext: context)
         let emotion = Emotion(
-            emotionType: .joy,
-            childActions: [],
-            parentActions: [],
+            emotionType: .anger,
+            childActions: [.crying],
+            parentActions: [.scolding],
             notes: "Test note"
         )
         
@@ -74,25 +74,25 @@ struct HomeViewStateTests {
     @Test("deleteEmotions - deletes multiple emotions by index")
     func testDeleteEmotions() async throws {
         // 準備
-        let (context, recorder) = try await MainActor.run { try createTestContext() }
+        let (context, recorder) = try createTestContext()
         let viewState = HomeViewState(modelContext: context)
         
         let emotion1 = Emotion(
-            emotionType: .joy,
-            childActions: [],
-            parentActions: [],
+            emotionType: .anger,
+            childActions: [.crying],
+            parentActions: [.scolding],
             notes: "Test note 1"
         )
         let emotion2 = Emotion(
-            emotionType: .anger,
-            childActions: [],
-            parentActions: [],
+            emotionType: .joy,
+            childActions: [.laughing],
+            parentActions: [.praising],
             notes: "Test note 2"
         )
         let emotion3 = Emotion(
-            emotionType: .fear,
-            childActions: [],
-            parentActions: [],
+            emotionType: .sadness,
+            childActions: [.crying],
+            parentActions: [.hugging],
             notes: "Test note 3"
         )
         let emotions = [emotion1, emotion2, emotion3]
@@ -107,5 +107,55 @@ struct HomeViewStateTests {
         #expect(recorder.deletedObjects.contains(where: { ($0 as? Emotion) === emotion1 }))
         #expect(recorder.deletedObjects.contains(where: { ($0 as? Emotion) === emotion3 }))
         #expect(!recorder.deletedObjects.contains(where: { ($0 as? Emotion) === emotion2 }))
+    }
+    
+    @Test("groupEmotionsByMonth - グループ化と並び順のテスト")
+    func testGroupEmotionsByMonth() async throws {
+        // 準備
+        let (context, _) = try createTestContext()
+        let viewState = HomeViewState(modelContext: context)
+        
+        let calendar = Calendar.current
+        let now = Date()
+        let lastMonth = calendar.date(byAdding: .month, value: -1, to: now)!
+        let twoMonthsAgo = calendar.date(byAdding: .month, value: -2, to: now)!
+        
+        // 各日付に感情を作成
+        let angryEmotion = Emotion(emotionType: .anger, childActions: [], parentActions: [], notes: "")
+        angryEmotion.timestamp = now
+        
+        let joyEmotion = Emotion(emotionType: .joy, childActions: [], parentActions: [], notes: "")
+        joyEmotion.timestamp = now
+        
+        let sadEmotion = Emotion(emotionType: .sadness, childActions: [], parentActions: [], notes: "")
+        sadEmotion.timestamp = lastMonth
+        
+        let anxietyEmotion = Emotion(emotionType: .anxiety, childActions: [], parentActions: [], notes: "")
+        anxietyEmotion.timestamp = twoMonthsAgo
+        
+        let emotions = [angryEmotion, joyEmotion, sadEmotion, anxietyEmotion]
+        
+        // 実行
+        let sections = viewState.groupEmotionsByMonth(emotions)
+        
+        // 検証
+        // 1. セクションの数が正しいこと
+        #expect(sections.count == 3)
+        
+        // 2. セクション内の感情の数が正しいこと
+        #expect(sections[0].emotions.count == 2) // 今月
+        #expect(sections[1].emotions.count == 1) // 先月
+        #expect(sections[2].emotions.count == 1) // 2ヶ月前
+        
+        // 3. セクションが日付の降順でソートされていること
+        let dates = sections.map { $0.month }
+        #expect(dates[0] > dates[1])
+        #expect(dates[1] > dates[2])
+        
+        // 4. 各セクションに正しい感情が含まれていること
+        #expect(sections[0].emotions.contains { $0.emotionType == .anger })
+        #expect(sections[0].emotions.contains { $0.emotionType == .joy })
+        #expect(sections[1].emotions.contains { $0.emotionType == .sadness })
+        #expect(sections[2].emotions.contains { $0.emotionType == .anxiety })
     }
 }


### PR DESCRIPTION
## 概要

感情データを月別にグループ化して表示するように変更し、各グループにはその月を表す日本語のヘッダーを追加しました。

## 変更内容

- HomeViewStateにMonthSection構造体とgroupEmotionsByMonthメソッドを追加
- HomeViewでForEachを使ってセクション単位でのリスト表示を実装
- HomeViewStateのテストコードにgroupEmotionsByMonthのテストを追加

## レビュアーへの補足情報

- 月ごとのグループ化はCalendarの機能を使用して年月単位で行っています
- 月別セクションは日付の降順（新しい順）でソートされています

## 手動でテストが必要な箇所

- [x] ホーム画面で感情データが月別に正しくグループ化されていることの確認
- [x] 異なる月のデータを作成した際に、適切なセクションに表示されることの確認
- [x] 編集モード時にも月別表示が維持されていることの確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Emotions are now organized by month with clear section headers, making it easier to navigate your records.
  - Both editing and viewing modes have been enhanced for better clarity and usability while keeping interactive features such as tapping for details and enabling context actions intact.
  
- **Version Update**
  - The app version has been updated from 1.5 to 1.6, reflecting the latest enhancements and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->